### PR TITLE
Handle missing PySide6 gracefully

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1,4 +1,11 @@
-from PySide6 import QtWidgets, QtGui, QtCharts, QtCore
+try:
+    from PySide6 import QtWidgets, QtGui, QtCharts, QtCore
+except ImportError as e:  # pragma: no cover - only runs without PySide6
+    raise ImportError(
+        "PySide6 or underlying Qt libraries are missing. "
+        "Install PySide6 via 'pip install pyside6' and ensure Qt/\n"
+        "libEGL packages are installed (e.g. on Ubuntu: 'sudo apt-get install libegl1')."
+    ) from e
 import pandas as pd, qasync, asyncio
 
 class ProgressChart(QtWidgets.QWidget):


### PR DESCRIPTION
## Summary
- raise informative ImportError in `ui.py` when PySide6/Qt libs are missing
- update `main.py` to catch ImportError, print installation guidance and fall back to a console UI
- add simple CLI class for non-GUI operation

## Testing
- `pip install pytest_asyncio`
- `pip install aiosqlite duckdb pandas`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee7d1852483278b7d5ea38be54e2e