### PR TITLE
Add better_profanity dependency for LLM output validation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,6 @@ python-multipart==0.0.6
 aiofiles==23.2.1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
-
 # Existing dependencies we'll reuse
 pyyaml==6.0.2
 aiosqlite==0.20.0
@@ -20,6 +19,7 @@ pyaudio==0.2.14
 torch==2.3.0
 backoff==2.2.1
 tiktoken==0.7.0
-
 # STT
 faster-whisper==1.0.3
+# LLM validation and filtering
+better_profanity==0.7.0


### PR DESCRIPTION
Added better_profanity==0.7.0 to requirements.txt to support profanity filtering in LLM endpoint responses.